### PR TITLE
Fix some compiler warnings (Cocoa)

### DIFF
--- a/cocoa/base/AppDelegateBase.h
+++ b/cocoa/base/AppDelegateBase.h
@@ -17,7 +17,7 @@ http://www.gnu.org/licenses/gpl-3.0.html
 #import "HSRecentFiles.h"
 #import "HSProgressWindow.h"
 
-@interface AppDelegateBase : NSObject
+@interface AppDelegateBase : NSObject <NSFileManagerDelegate>
 {
     NSMenu *recentResultsMenu;
     NSMenu *columnsMenu;


### PR DESCRIPTION
Hi Virgil what do you think about this pull request?

Cocoa:
Use NSModalResponse enums
Use NSModalResponse enums in files in cocoalib directory
Fix a warning by declaring that AppDelegateBase conforms to NSFileManagerDelegate