### PR TITLE
Include dbm.dumb for windows build

### DIFF
--- a/package.py
+++ b/package.py
@@ -143,7 +143,7 @@ def package_windows():
         'build_exe': {
             'build_exe': buildpath,
             'excludes': [],
-            'includes': ['atexit'],
+            'includes': ['atexit', 'dbm.dumb'],
             'include_files': include_files,
             'include_msvcr': True,
             'zip_include_packages': ['*'],


### PR DESCRIPTION
cx_Freeze was only including dbm.ndbm which is not available on windows.
This should fix hsoft/dupeguru#474