### PR TITLE
Replace unsafe eval() with ast.literal_eval()

### DIFF
--- a/hscommon/pygettext.py
+++ b/hscommon/pygettext.py
@@ -14,6 +14,7 @@
 # Made docstring fit in 80 chars wide displays using pydoc.
 #
 
+import ast
 import os
 import importlib.machinery
 import importlib.util
@@ -81,7 +82,7 @@ def escape(s):
 
 def safe_eval(s):
     # unwrap quotes, safely
-    return eval(s, {"__builtins__": {}}, {})
+    return ast.literal_eval(s)
 
 
 def normalize(s):


### PR DESCRIPTION
## Context

During a security audit of dupeGuru, we identified **unsafe use of Python'"'"'s built-in code evaluation** in the i18n/localization tooling.

## Vulnerability

The `safe_eval()` function in `hscommon/pygettext.py` (line 82-84) is intended to safely unwrap quoted strings from Python source code during gettext extraction:

```python
def safe_eval(s):
    # unwrap quotes, safely
    return eval(s, {"__builtins__": {}}, {})
```

Despite the restricted builtins, Python'"'"'s `eval()` can still be exploited through various techniques (e.g., accessing `__subclasses__()` via object introspection, or using comprehensions to reconstruct dangerous functions). The "restricted builtins" pattern is a known-broken security measure.

This function processes string literals extracted from Python source files during the localization build process. If a contributor submits a malicious string literal in a translatable `_()` call, it would be evaluated during the build.

## Fix

Replace `eval()` with `ast.literal_eval()`, which is Python'"'"'s standard safe alternative:

```python
import ast

def safe_eval(s):
    # unwrap quotes, safely
    return ast.literal_eval(s)
```

`ast.literal_eval()` only parses Python literal expressions (strings, bytes, numbers, tuples, lists, dicts, sets, booleans, and `None`). It **cannot** call functions, import modules, or execute arbitrary code. This is exactly what'"'"'s needed here — the function only needs to unwrap quoted string literals.

## Test plan

- [x] Verified `safe_eval()` correctly unwraps single-quoted and double-quoted strings
- [x] `python build.py` succeeds (this file is used during localization builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)